### PR TITLE
Add Image.text_size()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image-builder"
-version = "1.0.0"
+version = "1.0.2"
 edition = "2021"
 description = "Image Builder is a high-level library that uses the image crate as the engine to generate PNG images, but with convenience and simplicity."
 license = "MIT"

--- a/src/image.rs
+++ b/src/image.rs
@@ -144,12 +144,12 @@ impl<'a> Image<'a> {
                         .expect(&format!("Unable to load the picture \"{}\"", p.path))
                         .to_rgba8();
 
+                    if let Some(values) = p.resize {
+                        pic = resize(&mut pic, values.nwidth, values.nheight, values.filter)
+                    }
                     if let Some(values) = p.crop {
                         pic = crop(&mut pic, values.x, values.y, values.width, values.height)
                             .to_image();
-                    }
-                    if let Some(values) = p.resize {
-                        pic = resize(&mut pic, values.nwidth, values.nheight, values.filter)
                     }
 
                     overlay(&mut image, &pic, p.x, p.y);

--- a/src/image.rs
+++ b/src/image.rs
@@ -37,12 +37,21 @@ pub enum Element {
 /// is essential to keep this order in mind when creating images with multiple elements to ensure that
 /// the elements are in the desired order.
 /// ## Examples
-/// ```
+/// ```rust
+/// # use image_builder::Image;
+/// # use image_builder::Rect;
+/// # use image_builder::Text;
+/// # use image_builder::colors;
 /// let mut image = Image::new(500, 500, colors::WHITE);
 /// image.add_text(Text::new("Image Builder"));
 /// image.add_rect(Rect::new().size(200, 200)); // This rectangle covers the text.
 /// ```
-/// ```
+///
+/// ```rust
+/// # use image_builder::Image;
+/// # use image_builder::Rect;
+/// # use image_builder::Text;
+/// # use image_builder::colors;
 /// let mut image = Image::new(500, 500, colors::WHITE);
 /// image.add_rect(Rect::new().size(200, 200)); // This rectangle is in the background of the text.
 /// image.add_text(Text::new("Image Builder"));
@@ -85,8 +94,9 @@ impl<'a> Image<'a> {
     /// ```
     /// use image_builder::Image;
     /// use std::fs;
+    /// use image_builder::colors;
     ///
-    /// let mut image = //Image::new...
+    /// let mut image = Image::new(500, 500, colors::WHITE);
     /// let roboto_bold = fs::read("fonts/Roboto/Roboto-Bold.ttf").unwrap();
     /// image.add_custom_font("Roboto bold", roboto_bold);
     /// ```

--- a/src/image.rs
+++ b/src/image.rs
@@ -20,6 +20,7 @@ use crate::{
     text::{self, Text},
 };
 
+#[derive(Clone)]
 pub enum Element {
     Text(Text),
     Rect(Rect),
@@ -56,6 +57,7 @@ pub enum Element {
 /// image.add_rect(Rect::new().size(200, 200)); // This rectangle is in the background of the text.
 /// image.add_text(Text::new("Image Builder"));
 /// ```
+#[derive(Clone)]
 pub struct Image<'a> {
     background: Color,
     size: (u32, u32),

--- a/src/image.rs
+++ b/src/image.rs
@@ -5,7 +5,7 @@ pub use image::imageops::FilterType;
 use image::{
     codecs::png::PngEncoder,
     imageops::{crop, overlay, resize},
-    open, ImageBuffer, ImageEncoder, Rgba,
+    ImageBuffer, ImageEncoder, Rgba,
 };
 use imageproc::{
     drawing::{draw_filled_rect_mut, draw_text_mut, text_size},
@@ -142,9 +142,7 @@ impl<'a> Image<'a> {
             match element {
                 Element::Picture(element) => {
                     let p = picture::extract(element);
-                    let mut pic = open(p.path)
-                        .expect(&format!("Unable to load the picture \"{}\"", p.path))
-                        .to_rgba8();
+                    let mut pic = p.img.to_rgba8();
 
                     if let Some(values) = p.resize {
                         pic = resize(&mut pic, values.nwidth, values.nheight, values.filter)

--- a/src/image.rs
+++ b/src/image.rs
@@ -8,7 +8,7 @@ use image::{
     open, ImageBuffer, ImageEncoder, Rgba,
 };
 use imageproc::{
-    drawing::{draw_filled_rect_mut, draw_text_mut},
+    drawing::{draw_filled_rect_mut, draw_text_mut, text_size},
     rect as procRect,
 };
 use rusttype::Font;
@@ -115,6 +115,14 @@ impl<'a> Image<'a> {
     /// This method allows for adding formatted text to the image being built. Refer to the [`Text`] for more details.
     pub fn add_text(&mut self, text: Text) {
         self.elements.push(Element::Text(text));
+    }
+
+    /// This method can be used before `add_text` to reqeust the expected width and height of a
+    /// text element.
+    pub fn text_size(&mut self, text: &Text) -> (i32, i32) {
+        let t = text::extract(&text);
+        let font = self.fonts.get(t.font_name).expect(&format!("Unable to load the \"{}\" font, please verify that the name is correct or that it was loaded using the \"add_custom_font\" method.", t.font_name));
+        text_size(t.scale, font, &t.content)
     }
 
     /// This method allows for adding rectangular shapes to the image being built. Refer to the [`Rect`] for more details.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 use std::fs;
+use std::io::Cursor;
 
+use image::io::Reader as ImageReader;
+use image::DynamicImage;
 use image_builder::{colors, FilterType, Image, Picture, Rect, Text};
 
 fn main() {
@@ -8,7 +11,6 @@ fn main() {
     let mut image = Image::new(width, height, colors::GRAY);
 
     let roboto_bold = fs::read("fonts/Roboto/Roboto-Bold.ttf").unwrap();
-
     image.add_custom_font("Roboto bold", roboto_bold);
 
     image.add_rect(
@@ -25,8 +27,14 @@ fn main() {
             .color(colors::GRAY),
     );
 
+    let logo = fs::read("logo.png").unwrap();
+    let img: DynamicImage = ImageReader::new(Cursor::new(logo))
+        .with_guessed_format()
+        .expect("jpg or png")
+        .decode()
+        .unwrap();
     image.add_picture(
-        Picture::new("logo.png")
+        Picture::new(img)
             .resize(134, 83, FilterType::Triangle)
             .crop(41, 143, 536, 332)
             .position(233, 30),

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -1,4 +1,5 @@
 use image::imageops::FilterType;
+use image::DynamicImage;
 
 /// External images.
 ///
@@ -11,9 +12,11 @@ use image::imageops::FilterType;
 /// ## Example
 /// ```
 /// # use image_builder::FilterType;
+/// # let file_bytes:Vec<u8> = Vec::new();
 /// use image_builder::Picture;
+/// use image::DynamicImage;
 ///
-/// Picture::new("/home/user/logo.png")
+/// Picture::new(file_bytes)
 ///     .resize(100, 100, FilterType::Triangle) // Resizing is specified here, but the library will first perform the cropping below, and then this resizing.
 ///     .crop(50, 50, 200, 200);
 /// ```
@@ -21,7 +24,7 @@ use image::imageops::FilterType;
 /// cropped, and then this cropped portion was resized by half, resulting in an image of 100x100 pixels.
 #[derive(Clone)]
 pub struct Picture {
-    path: String,
+    img: image::DynamicImage,
     crop: Option<(u32, u32, u32, u32)>,
     resize: Option<(u32, u32, FilterType)>,
     position: (u32, u32),
@@ -31,14 +34,14 @@ impl Picture {
     /// and positions it at the point (0,0) of the image being built.
     /// ## Example
     /// ```
+    /// use image::DynamicImage;
     /// use image_builder::Picture;
     ///
-    /// Picture::new("/home/user/logo.png");
+    /// Picture::new(image);
     /// ```
-    pub fn new(path: &str) -> Picture {
-        let path = String::from(path);
+    pub fn new(img: DynamicImage) -> Picture {
         Picture {
-            path,
+            img,
             resize: None,
             crop: None,
             position: (0, 0),
@@ -104,7 +107,7 @@ pub struct ResizeValues {
 
 #[derive(Clone)]
 pub struct PictureValues<'a> {
-    pub path: &'a String,
+    pub img: &'a DynamicImage,
     pub x: i64,
     pub y: i64,
     pub crop: Option<CropValues>,
@@ -112,7 +115,7 @@ pub struct PictureValues<'a> {
 }
 pub fn extract(picture: &Picture) -> PictureValues {
     PictureValues {
-        path: &picture.path,
+        img: &picture.img,
         x: picture.position.0 as i64,
         y: picture.position.1 as i64,
         crop: match picture.crop {

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -10,6 +10,7 @@ use image::imageops::FilterType;
 /// image, the library will always perform cropping first, and then resizing.** ⚠️
 /// ## Example
 /// ```
+/// # use image_builder::FilterType;
 /// use image_builder::Picture;
 ///
 /// Picture::new("/home/user/logo.png")
@@ -46,7 +47,8 @@ impl Picture {
 
     /// This method allows resizing an image by specifying the desired new height, width and [`FilterType`].
     /// ## Example
-    /// ```
+    /// ```rust
+    /// # use image_builder::FilterType;
     /// use image_builder::Picture;
     ///
     /// Picture::new("/home/user/logo.png")

--- a/src/picture.rs
+++ b/src/picture.rs
@@ -87,17 +87,22 @@ impl Picture {
     }
 }
 
+#[derive(Clone)]
 pub struct CropValues {
     pub x: u32,
     pub y: u32,
     pub width: u32,
     pub height: u32,
 }
+
+#[derive(Clone)]
 pub struct ResizeValues {
     pub nwidth: u32,
     pub nheight: u32,
     pub filter: FilterType,
 }
+
+#[derive(Clone)]
 pub struct PictureValues<'a> {
     pub path: &'a String,
     pub x: i64,

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -71,6 +71,7 @@ impl Rect {
     }
 }
 
+#[derive(Clone)]
 pub struct RectValues {
     pub x: i32,
     pub y: i32,

--- a/src/text.rs
+++ b/src/text.rs
@@ -94,6 +94,7 @@ impl Text {
     }
 }
 
+#[derive(Clone)]
 pub struct TextValues<'a> {
     pub color: Rgba<u8>,
     pub x: i32,


### PR DESCRIPTION
Allow fetching text width so that we can center or right align text against a certain coordinate.

This small patch is donated to the public domain. Do with it as you wish. No warrantee given or implied. (MIT License)